### PR TITLE
Feature/miscell pipeline harmonisation updates

### DIFF
--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -1,0 +1,285 @@
+name: pnpm Audit & Auto-fix
+
+on:
+  schedule:
+    # Run daily at 00:05 UTC (10:05 AEST) — offset to avoid caching delays on CVE publication
+    - cron: '5 0 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  audit-and-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+
+      - run: corepack enable
+
+      - name: Install yq
+        uses: mikefarah/yq@master
+
+      - name: Check existing open audit PRs
+        id: check-existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find open PRs from previous audit runs
+          EXISTING_PR=$(gh pr list \
+            --state open \
+            --search "chore: fix pnpm audit vulnerabilities in:title" \
+            --json number,headRefName \
+            --jq '.[0] // empty')
+
+          if [[ -z "$EXISTING_PR" ]]; then
+            echo "existing_pr=false" >> "$GITHUB_OUTPUT"
+            echo "No existing audit PR found."
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+          PR_BRANCH=$(echo "$EXISTING_PR" | jq -r '.headRefName')
+          echo "existing_pr=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "pr_branch=${PR_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Found existing audit PR #${PR_NUMBER} on branch ${PR_BRANCH}"
+
+      - name: Test if existing PR still resolves audit
+        id: test-existing
+        if: steps.check-existing.outputs.existing_pr == 'true'
+        run: |
+          PR_BRANCH="${{ steps.check-existing.outputs.pr_branch }}"
+
+          # Checkout the PR branch and test audit
+          git fetch origin "$PR_BRANCH"
+          git checkout "$PR_BRANCH"
+
+          pnpm install --frozen-lockfile --ignore-scripts
+
+          if pnpm audit > /dev/null 2>&1; then
+            echo "pr_still_valid=true" >> "$GITHUB_OUTPUT"
+            echo "Existing PR still passes audit — nothing to do."
+          else
+            echo "pr_still_valid=false" >> "$GITHUB_OUTPUT"
+            echo "Existing PR no longer resolves all vulnerabilities."
+          fi
+
+      - name: Close stale PR
+        if: |
+          steps.check-existing.outputs.existing_pr == 'true' &&
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.check-existing.outputs.pr_number }}"
+          PR_BRANCH="${{ steps.check-existing.outputs.pr_branch }}"
+
+          gh pr close "$PR_NUMBER" \
+            --comment "Closing: this PR no longer resolves all current audit vulnerabilities. A new PR will be generated." \
+            --delete-branch
+
+          echo "Closed stale PR #${PR_NUMBER} and deleted branch ${PR_BRANCH}."
+
+      - name: Re-checkout main
+        if: |
+          steps.check-existing.outputs.existing_pr != 'true' ||
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        run: |
+          git checkout main
+          git pull origin main
+
+      - name: Install dependencies
+        id: install
+        if: |
+          steps.check-existing.outputs.existing_pr != 'true' ||
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Run pnpm audit
+        id: audit
+        if: |
+          steps.check-existing.outputs.existing_pr != 'true' ||
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        run: |
+          set -o pipefail
+          if pnpm audit 2>&1 | tee audit-output.txt; then
+            echo "has_vulnerabilities=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_vulnerabilities=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attempt pnpm upgrade
+        id: upgrade
+        if: steps.audit.outputs.has_vulnerabilities == 'true'
+        run: |
+          set -o pipefail
+          # Try a standard upgrade to resolve vulnerabilities
+          # --ignore-scripts avoids running lifecycle hooks (e.g. prepare: pre-commit install)
+          pnpm upgrade --ignore-scripts
+
+          # Re-run audit to see if upgrade resolved issues
+          if pnpm audit 2>&1 | tee audit-after-upgrade.txt; then
+            echo "upgrade_fixed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "upgrade_fixed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attempt pnpm audit --fix=override
+        id: audit-fix
+        if: steps.upgrade.outputs.upgrade_fixed == 'false'
+        run: |
+          set -o pipefail
+          # Remove existing overrides to prevent stale/conflicting ranges accumulating
+          if [ -f pnpm-workspace.yaml ]; then yq -i 'del(.overrides)' pnpm-workspace.yaml; fi
+
+          # Reinstall to regenerate lockfile without old overrides
+          pnpm install --no-frozen-lockfile --ignore-scripts
+
+          # Use pnpm audit --fix=override to add fresh overrides for vulnerable transitive deps
+          pnpm audit --fix=override 2>&1 | tee audit-fix-output.txt || true
+
+          # Reinstall with the new overrides
+          pnpm install --no-frozen-lockfile --ignore-scripts
+
+          # Verify the fix resolved the issues
+          if pnpm audit 2>&1 | tee audit-after-fix.txt; then
+            echo "audit_fix_resolved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "audit_fix_resolved=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine fix method
+        id: fix-method
+        if: |
+          steps.upgrade.outputs.upgrade_fixed == 'true' ||
+          steps.audit-fix.outputs.audit_fix_resolved == 'true'
+        run: |
+          if [[ "${{ steps.upgrade.outputs.upgrade_fixed }}" == "true" ]]; then
+            echo "method=pnpm upgrade" >> "$GITHUB_OUTPUT"
+          else
+            echo "method=pnpm audit --fix=override" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tracking issue
+        id: create-issue
+        if: |
+          steps.upgrade.outputs.upgrade_fixed == 'true' ||
+          steps.audit-fix.outputs.audit_fix_resolved == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FIX_METHOD="${{ steps.fix-method.outputs.method }}"
+
+          ISSUE_URL=$(gh issue create \
+            --title "Security: pnpm audit vulnerabilities ($(date +%Y-%m-%d))" \
+            --label "security,dependencies" \
+            --body "## Security Audit Vulnerabilities
+
+          The daily \`pnpm audit\` workflow detected vulnerabilities and was able to resolve them automatically.
+
+          **Fix method:** \`${FIX_METHOD}\`
+
+          A PR has been created to address these vulnerabilities. This issue will be closed when the PR is merged.")
+
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+          echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR with verified commit
+        if: |
+          steps.upgrade.outputs.upgrade_fixed == 'true' ||
+          steps.audit-fix.outputs.audit_fix_resolved == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: chore/pnpm-audit-fix-${{ github.run_id }}
+          add-paths: |
+            package.json
+            pnpm-workspace.yaml
+            pnpm-lock.yaml
+          commit-message: 'chore: fix security vulnerabilities via ${{ steps.fix-method.outputs.method }}'
+          title: 'chore: fix pnpm audit vulnerabilities (${{ github.run_id }})'
+          body: |
+            ## Security Audit Auto-fix
+
+            This PR was automatically generated by the daily `pnpm audit` workflow.
+
+            **Fix method:** `${{ steps.fix-method.outputs.method }}`
+
+            Closes #${{ steps.create-issue.outputs.issue_number }}
+
+            ### What happened
+            - `pnpm audit` detected vulnerabilities in dependencies
+            - The workflow attempted to resolve them automatically
+            - All vulnerabilities were resolved
+
+            ### Next steps
+            - Review the dependency changes
+            - Ensure CI passes
+            - Merge when satisfied
+          labels: security,dependencies
+          delete-branch: true
+          sign-commits: true
+
+      - name: Create issue for unresolved vulnerabilities
+        if: |
+          steps.audit.outputs.has_vulnerabilities == 'true' &&
+          steps.upgrade.outputs.upgrade_fixed != 'true' &&
+          steps.audit-fix.outputs.audit_fix_resolved != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if there's already an open issue for unresolved audit vulnerabilities
+          EXISTING_ISSUE=$(gh issue list \
+            --state open \
+            --search "Security: unresolved pnpm audit vulnerabilities in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [[ -n "$EXISTING_ISSUE" ]]; then
+            # Add a comment with today's audit output to the existing issue
+            AUDIT_OUTPUT=$(cat audit-output.txt | head -100)
+            gh issue comment "$EXISTING_ISSUE" \
+              --body "## Daily audit re-check ($(date +%Y-%m-%d))
+
+          Vulnerabilities are still unresolved. Current audit output:
+
+          \`\`\`
+          ${AUDIT_OUTPUT}
+          \`\`\`"
+            echo "Updated existing issue #${EXISTING_ISSUE} with today's audit output."
+            exit 0
+          fi
+
+          AUDIT_OUTPUT=$(cat audit-output.txt | head -100)
+
+          gh issue create \
+            --title "Security: unresolved pnpm audit vulnerabilities ($(date +%Y-%m-%d))" \
+            --label "security,dependencies" \
+            --body "## Unresolved Security Vulnerabilities
+
+          The daily \`pnpm audit\` workflow found vulnerabilities that could not be automatically resolved.
+
+          ### Remediation attempts
+          1. ❌ \`pnpm upgrade\` — did not resolve all issues
+          2. ❌ \`pnpm audit --fix=override\` — did not resolve all issues
+
+          ### Audit output
+          \`\`\`
+          ${AUDIT_OUTPUT}
+          \`\`\`
+
+          ### Manual action required
+          - Review the vulnerable packages above
+          - Check if upstream fixes are available
+          - Consider replacing packages if no fix is forthcoming
+          - If the vulnerability is acceptable (e.g. dev-only, not exploitable in context), document the justification and close this issue"

--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -28,7 +28,7 @@ jobs:
       - run: corepack enable
 
       - name: Install yq
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4.53.3
 
       - name: Check existing open audit PRs
         id: check-existing

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,50 +1,40 @@
 name: Pull Request Tests
 
 on:
-  merge_group:
+  merge_group: {}
   pull_request:
-    paths-ignore:
-      # The ignore only works only if changes to the main branch only include the following files.
-      # So if the commit only contain .md changes but the PR change contain more, the ignore fails
-      # https://github.com/actions/runner/issues/2324#issuecomment-1703345084
-      - '**.md'
-      - '**.svg'
-      - '**.drawio'
-      - '**.png'
     types:
       - opened
       - reopened
       - synchronize
       - ready_for_review
-      - auto_merge_enabled
     branches:
       - main
 
 permissions: read-all
 
 # Actions Used (please keep this documented here as added)
-#  https://github.com/marketplace/actions/checkout
-#  https://github.com/marketplace/actions/setup-python
-#  https://github.com/marketplace/actions/trufflehog-oss
-#  https://github.com/marketplace/actions/checkout
-#  https://github.com/marketplace/actions/cache
-#  https://github.com/actions-rust-lang/setup-rust-toolchain
+#  https://github.com/marketplace/actions/checkout (v7)
+#  https://github.com/marketplace/actions/setup-node-js-environment (v7)
+#  https://github.com/marketplace/actions/setup-pnpm (v6)
+#  https://github.com/marketplace/actions/trufflehog-oss (v3.96.0)
+#  https://github.com/dorny/paths-filter (v4)
 
 jobs:
   pre-commit-lint-security:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft && github.repository != 'OrcaBus/template-service-base' }}
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'pnpm'
 
       - run: corepack enable
@@ -62,7 +52,7 @@ jobs:
           pip3 install pre-commit detect-secrets black ggshield
 
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.34.0
+        uses: trufflesecurity/trufflehog@v3.96.0
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
@@ -77,18 +67,48 @@ jobs:
         run: |
           make check
 
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.ts'
+              - '**/*.sh'
+              - '**/*.py'
+              - '**/package.json'
+              - '**/pnpm-lock.yaml'
+              - 'infrastructure/**'
+              - 'app/**'
+              - 'test/**'
+              - 'Makefile'
+              - '.github/**'
+              - 'cdk.json'
+              - 'tsconfig.json'
+              - 'jest.config.*'
   test-iac:
     runs-on: ubuntu-22.04-arm
-    # Template service base is broken with
-    if: ${{ !github.event.pull_request.draft && github.repository != 'OrcaBus/template-service-base' }}
+    # Excluded for template-service-base which has no application code to test
+    if: >-
+      !github.event.pull_request.draft &&
+      github.repository != 'OrcaBus/template-service-base' &&
+      needs.check-changes.outputs.should_test == 'true'
+    needs: check-changes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'pnpm'
 
       - run: corepack enable
@@ -96,3 +116,25 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm test
+
+  # This is the job you set as "required" in branch protection
+  ci-gate:
+    runs-on: ubuntu-latest
+    needs: [pre-commit-lint-security, check-changes, test-iac]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.pre-commit-lint-security.result }}" != "success" && "${{ needs.pre-commit-lint-security.result }}" != "skipped" ]]; then
+            echo "Lint/security checks did not succeed (result: ${{ needs.pre-commit-lint-security.result }})"
+            exit 1
+          fi
+          if [[ "${{ needs.check-changes.result }}" != "success" ]]; then
+            echo "Change detection did not succeed (result: ${{ needs.check-changes.result }})"
+            exit 1
+          fi
+          if [[ "${{ needs.test-iac.result }}" != "success" && "${{ needs.test-iac.result }}" != "skipped" ]]; then
+            echo "Tests did not succeed (result: ${{ needs.test-iac.result }})"
+            exit 1
+          fi
+          echo "CI passed (tests passed or were skipped)"

--- a/app/lambdas/get_missing_schema_fields_py/requirements.txt
+++ b/app/lambdas/get_missing_schema_fields_py/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema
+jsonschema==4.26.0

--- a/app/lambdas/validate_draft_payload_py/requirements.txt
+++ b/app/lambdas/validate_draft_payload_py/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema==4.24.0
+jsonschema==4.26.0

--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -606,7 +606,7 @@
                         "requirements": {
                           "hasQc": true,
                           "hasFingerprint": true,
-                          "hasActiveReadSet": true
+                          "hasActiveReadSet": "{% ($engineParameters.outputUri ~> $substring(0,$length('${__pipeline_cache_uri__}'))) = '${__pipeline_cache_uri__}' ? { 'bucket': '${__pipeline_cache_bucket__}', 'prefix': '${__pipeline_cache_prefix__}' } : true %}"
                         },
                         "forceUnarchiving": true
                       }

--- a/infrastructure/stage/config.ts
+++ b/infrastructure/stage/config.ts
@@ -26,6 +26,10 @@ import { ICAV2_PROJECT_ID } from '@orcabus/platform-cdk-constructs/shared-config
 import { substituteBucketConstants } from './utils';
 import { SsmParameterPaths, SsmParameterValues } from './ssm/interfaces';
 import { StatefulApplicationStackConfig, StatelessApplicationStackConfig } from './interfaces';
+import {
+  PIPELINE_CACHE_BUCKET,
+  PIPELINE_CACHE_PREFIX,
+} from '@orcabus/platform-cdk-constructs/shared-config/s3';
 
 export const getSsmParameterPaths = (): SsmParameterPaths => {
   return {
@@ -100,5 +104,9 @@ export const getStatelessApplicationStackProps = (
 
     // Event Bus Object
     eventBusName: EVENT_BUS_NAME,
+
+    // Pipeline cache bucket
+    pipelineCacheBucketName: PIPELINE_CACHE_BUCKET[stage],
+    pipelineCachePrefix: PIPELINE_CACHE_PREFIX[stage],
   };
 };

--- a/infrastructure/stage/interfaces.ts
+++ b/infrastructure/stage/interfaces.ts
@@ -19,6 +19,10 @@ export interface StatelessApplicationStackConfig {
 
   // Event Stuff
   eventBusName: string;
+
+  // Pipeline cache bucket
+  pipelineCacheBucketName: string;
+  pipelineCachePrefix: string;
 }
 
 export type WorkflowVersionType = '2.6.0' | '2.6.1';

--- a/infrastructure/stage/stateless-application-stack.ts
+++ b/infrastructure/stage/stateless-application-stack.ts
@@ -64,6 +64,8 @@ export class StatelessApplicationStack extends GitStack {
       eventBus: orcabusMainEventBus,
       ssmParameterPaths: props.ssmParameterPaths,
       fargateTabixTaskObj: fargateTabixTaskObj,
+      pipelineCacheBucketName: props.pipelineCacheBucketName,
+      pipelineCachePrefix: props.pipelineCachePrefix,
     });
 
     // Add event rules

--- a/infrastructure/stage/step-functions/index.ts
+++ b/infrastructure/stage/step-functions/index.ts
@@ -101,6 +101,12 @@ function createStateMachineDefinitionSubstitutions(props: BuildStepFunctionProps
       props.fargateTabixTaskObj.containerDefinition.containerName;
   }
 
+  // Pipeline cache
+  definitionSubstitutions['__pipeline_cache_uri__'] =
+    `s3://${props.pipelineCacheBucketName}/${props.pipelineCachePrefix}`;
+  definitionSubstitutions['__pipeline_cache_bucket__'] = props.pipelineCacheBucketName;
+  definitionSubstitutions['__pipeline_cache_prefix__'] = props.pipelineCachePrefix;
+
   return definitionSubstitutions;
 }
 
@@ -241,6 +247,8 @@ export function buildAllStepFunctions(
         eventBus: props.eventBus,
         ssmParameterPaths: props.ssmParameterPaths,
         fargateTabixTaskObj: props.fargateTabixTaskObj,
+        pipelineCacheBucketName: props.pipelineCacheBucketName,
+        pipelineCachePrefix: props.pipelineCachePrefix,
       })
     );
   }

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -37,6 +37,8 @@ export interface BuildStepFunctionProps extends StepFunctionInput {
   eventBus: IEventBus;
   ssmParameterPaths: SsmParameterPaths;
   fargateTabixTaskObj: EcsFargateTaskConstruct;
+  pipelineCacheBucketName: string;
+  pipelineCachePrefix: string;
 }
 
 export interface StepFunctionObject extends StepFunctionInput {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "organization": true
   },
   "license": "MIT",
-  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
+  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary

Miscellaneous pipeline harmonisation updates for the dragen-tso500-ctdna service, aligning CI workflows with cross-service standards and adding pipeline cache support.

## Changes

**CI/CD**
- Add daily `pnpm audit` workflow with automated vulnerability detection, remediation (upgrade or override), PR creation, and issue tracking
- Modernise `pr-tests.yml`: upgrade actions (checkout v7, setup-node v7, pnpm v6, trufflehog v3.96.0), replace `paths-ignore` with `dorny/paths-filter` for reliable skip detection, add a `ci-gate` job for branch protection, bump Node to 24.x

**Infrastructure**
- Wire pipeline cache bucket/prefix through CDK stack to Step Functions definition substitutions
- Update `populate_draft_data` state machine to conditionally use cache bucket requirements (`hasActiveReadSet` evaluates a JSONata expression) when the output URI targets the pipeline cache prefix

**Dependencies**
- Pin `jsonschema` to `4.26.0` across both lambdas that use it
- Bump pnpm from 11.10.0 to 11.17.0

### Testing
- Pre-commit hooks pass on all commits
- CI workflow YAML validates cleanly