### PR TITLE
fix: guard get_s3_key_prefix_by_project_id against ApiException and None

### DIFF
--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -315,7 +315,41 @@ def handler(event, context) -> Dict[str, bool]:
     engine_parameters = payload_data.get("engineParameters", {})
 
     # Get the project prefix
-    project_prefix = cast(str, get_s3_key_prefix_by_project_id(engine_parameters.get("projectId")))
+    project_id = engine_parameters.get("projectId")
+    if project_id is None:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                "Post schema validation failed: projectId is not set",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
+
+    try:
+        project_prefix = get_s3_key_prefix_by_project_id(project_id)
+    except ApiException:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                f"Post schema validation failed: cannot resolve S3 key prefix for projectId '{project_id}'",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
+
+    if project_prefix is None:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                f"Post schema validation failed: no S3 key prefix configured for projectId '{project_id}'",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
 
     # Collect all failure comments across all validation phases
     all_failures: List[str] = []
@@ -335,7 +369,7 @@ def handler(event, context) -> Dict[str, bool]:
         inputs = payload_data.get("inputs", {})
         is_valid, failures = validate_inputs(
             inputs,
-            project_id=engine_parameters.get("projectId"),
+            project_id=project_id,
             project_prefix=project_prefix,
         )
         if not is_valid:


### PR DESCRIPTION
## Summary

Adds defensive handling around `get_s3_key_prefix_by_project_id` in the `post_schema_validation` lambda.

The wrapica function can:
1. **Raise `ApiException`** — if the ICAv2 API call fails (network issues, auth problems, invalid project)
2. **Return `None`** — if the project has no storage configuration

Previously neither failure mode was handled — the lambda would crash with an uncontrolled exception. Now we:
- Validate `projectId` is set before calling
- Catch `ApiException`
- Check for `None` return
- Write a descriptive comment to the workflow run record
- Return `{"isValid": false}` gracefully

## Related PRs

This fix is being applied consistently across all pipeline manager services:
- OrcaBus/service-arriba-wgts-rna-pipeline-manager
- OrcaBus/service-bclconvert-interop-qc-pipeline-manager
- OrcaBus/service-dragen-tso500-ctdna-pipeline-manager
- OrcaBus/service-dragen-wgts-dna-pipeline-manager
- OrcaBus/service-dragen-wgts-rna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-dna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-rna-pipeline-manager
- OrcaBus/service-sash-pipeline-manager